### PR TITLE
Add enterprise-level FixIt checklist tracks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2503,43 +2503,154 @@ With Appendices A–C, GPT‑Codex (or any developer) has the **entity map**, **
 44. [x] Deliver 7.6–7.8 Secrets management, AppSec automation, and privacy compliance — Functionality grade [100/100] | Integration grade [100/100] | UI:UX grade [100/100] | Security grade [100/100]
 45. [x] Deliver 7.9–7.10 Security runbooks, incident response, and acceptance testing — Functionality grade [100/100] | Integration grade [100/100] | UI:UX grade [100/100] | Security grade [100/100]
 46. [ ] Implement 8.1 Admin modules for moderation, disputes, and commerce oversight — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **46A — Domain scoping & IA**: Identify the moderation, disputes, and commerce oversight use cases; document required data models, permissions, and navigation structure with wireframes that surface priority queues.
+    - **46B — Workflow enablement & QA**: Implement module screens, hook up API endpoints, and script QA scenarios covering reviewer actions, escalation, and audit logging with accessibility validation.
 47. [ ] Implement 8.2–8.3 Ops observability dashboards and alerting with SLOs — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **47A — Metrics inventory & dashboard design**: Gather target SLOs, define metrics sources (APM, logs, queues), and draft dashboard layouts highlighting latency/error budgets for ops personas.
+    - **47B — Alert routing & validation**: Configure data pipelines, alerts, and runbooks; test paging rules, suppression logic, and post-mortem feedback loops across staging and production mirrors.
 48. [ ] Implement 8.4–8.5 Product analytics instrumentation and admin acceptance checks — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **48A — Event taxonomy & tagging**: Define analytics events for admin journeys, implement tracking hooks, and ensure schema alignment with data warehouse contracts.
+    - **48B — Reporting QA & acceptance**: Build dashboards and acceptance criteria validating event completeness, privacy filters, and stakeholder reporting needs with automated regression scripts.
 49. [ ] Deliver 9.1–9.2 Ads slot registry, rendering, and fill waterfall — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **49A — Registry modeling & API enablement**: Design slot inventory schema, targeting metadata, and CRUD APIs with validation and audit trails.
+    - **49B — Rendering logic & fill testing**: Implement slot renderer components, waterfall logic, and simulators verifying fill rates, fallback behaviors, and performance budgets.
 50. [ ] Deliver 9.3–9.7 Creative specs, measurement, privacy, performance budgets, and admin UX for ads — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **50A — Creative guidelines & instrumentation**: Publish creative spec documentation, asset validation tooling, and measurement hooks for impressions/clicks with privacy guards.
+    - **50B — Admin workflow & compliance QA**: Build admin review surfaces, performance dashboards, and conduct privacy/perf audits ensuring adherence to budgets and consent frameworks.
 51. [ ] Execute 10.1–10.4 Affiliate program foundations (entities, tracking, tiers, payouts) — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **51A — Entity modeling & onboarding**: Finalize affiliate entities, tier rules, and onboarding flows with validation and fraud safeguards.
+    - **51B — Tracking & payout pipelines**: Implement click/conversion tracking, ledger accruals, and payout scheduling with reconciliation tests.
 52. [ ] Execute 10.5–10.9 Affiliate fraud controls, API/events, dashboards, admin tooling, and acceptance — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **52A — Fraud detection & API exposure**: Build anomaly detection rules, event streams, and API endpoints for affiliate monitoring.
+    - **52B — Admin tooling & reporting acceptance**: Deliver review dashboards, alert workflows, and acceptance tests covering suspension, appeals, and data export scenarios.
 53. [ ] Execute 11.1–11.2 Zones standards with SRID, H3 computation, and storage — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **53A — Standards definition & schema setup**: Define SRID usage, H3 resolution strategy, and storage schema with migration scripts.
+    - **53B — Computation services & validation**: Implement H3 computation services, backfill utilities, and validation harnesses ensuring spatial accuracy.
 54. [ ] Execute 11.3–11.7 Zone matching, backfill, geocoding, permissions, and acceptance — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **54A — Matching algorithms & geocoding**: Develop zone matching logic, geocoding integrations, and caching strategies.
+    - **54B — Permissions, UIs & acceptance**: Wire permissions, admin/editor UIs, and acceptance tests covering backfill, overrides, and auditing.
 55. [ ] Execute 12.1–12.3 Meilisearch index tuning, relevancy scoring, and document normalization — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **55A — Index modeling & ingestion**: Define document schemas, tokenization rules, and ingestion pipelines with normalization scripts.
+    - **55B — Relevancy tuning & benchmarking**: Calibrate ranking rules, synonyms, and evaluation datasets with automated relevancy reports.
 56. [ ] Execute 12.4–12.8 Query parsing, Meilisearch personalization, feedback loops, performance, and acceptance — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **56A — Query features & personalization**: Implement advanced query parsing, filters, and personalization signals with privacy controls.
+    - **56B — Feedback, performance & acceptance**: Build feedback capture, latency monitoring, and acceptance tests verifying result quality across personas.
 57. [ ] Map 13) Dispute system user journeys and escalation handling — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **57A — Journey mapping & persona workshops**: Document user personas, touchpoints, and escalation triggers across disputes lifecycle with stakeholder interviews.
+    - **57B — Artefact production & validation**: Produce journey maps, service blueprints, and validation sessions ensuring coverage of edge cases and compliance checkpoints.
 58. [ ] Map 14) Payments & Escrow scenarios for lifecycle coverage — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **58A — Scenario cataloging & data flows**: Enumerate payment/escrow scenarios, model data flows, and identify integration points with partners.
+    - **58B — Risk reviews & acceptance**: Facilitate compliance reviews, finalize acceptance criteria, and capture evidence for lifecycle sign-off.
 59. [ ] Map 15) Storefront eCommerce scenarios across inventory, carts, and fulfillment — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **59A — Experience walkthroughs & state diagrams**: Document customer/provider journeys, state machines, and inventory impacts.
+    - **59B — Validation workshops & deliverables**: Run cross-team reviews, deliver annotated flows, and record acceptance coverage for carts, payments, and fulfillment.
 60. [ ] Map 16) Moderation, bad-word detection, and file scanning operations — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **60A — Policy discovery & threat modeling**: Catalogue moderation policies, bad-word lexicons, and file scanning requirements with threat models.
+    - **60B — Process design & evidence capture**: Define reviewer workflows, escalation playbooks, and gather artefacts demonstrating detection coverage and SLAs.
 61. [ ] Map 17) Speed upgrades and performance backlog prioritization — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **61A — Baseline diagnostics & backlog mining**: Capture performance baselines, identify hotspots, and draft backlog candidates with sizing.
+    - **61B — Prioritization framework & roadmap**: Establish scoring model, align stakeholders, and publish performance roadmap with milestones and acceptance signals.
 62. [ ] Deliver 18.1–18.3 Mobile redesign navigation, layout, dark mode, and motion system — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **62A — Navigation IA & layout prototypes**: Produce navigation architecture, wireframes, and layout prototypes covering key screens with accessibility considerations.
+    - **62B — Dark mode & motion system delivery**: Implement theming tokens, motion guidelines, and QA runs verifying contrast, animations, and device coverage.
 63. [ ] Deliver 18.4–18.7 Mobile redesign skeleton loaders, offline UX, accessibility, and quality bars — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **63A — Skeleton & offline experience design**: Design skeleton loaders, offline states, and recovery messaging with prototypes and copy guidelines.
+    - **63B — Accessibility & QA enforcement**: Execute accessibility audits, add automated tests, and document quality gates for the redesigned flows.
 64. [ ] Implement 19.1–19.3 CI/CD branching, GitHub Actions, and deployment automations — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **64A — Workflow architecture & branching policy**: Define branching strategy, environment matrix, and GitHub Actions workflow designs.
+    - **64B — Automation rollout & validation**: Implement pipelines, environment promotions, and smoke tests ensuring deployments meet rollback and audit requirements.
 65. [ ] Implement 19.4–19.6 Environment configuration, release management, and observability in CI/CD — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **65A — Configuration management & secrets flow**: Document environment variables, secret rotation, and config validation scripts integrated into CI/CD.
+    - **65B — Release orchestration & monitoring hooks**: Establish release calendar, automated change logs, and observability hooks with alert verification.
 66. [ ] Design 20.1–20.2 Admin UX layouts and list views — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **66A — Layout system foundations**: Draft responsive grid, typography, and spacing tokens tailored to admin personas.
+    - **66B — List view variants & validation**: Produce high-fidelity list view designs, interaction specs, and usability validation sessions.
 67. [ ] Design 20.3–20.4 Admin detail, audit, and safety views — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **67A — Detail view structure & audit requirements**: Map data density, timelines, and audit log presentation for detail screens.
+    - **67B — Safety workflows & prototype testing**: Design safety action modals, confirmation flows, and run prototype tests with admin stakeholders.
 68. [ ] Define 21.1–21.2 Unit and integration testing coverage plans — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **68A — Inventory & gap analysis**: Audit existing unit/integration coverage, document gaps, and prioritize components/services needing tests.
+    - **68B — Coverage roadmap & guardrails**: Produce coverage targets, ownership matrix, and guardrails (branch checks, CI gates) with rollout schedule.
 69. [ ] Define 21.3–21.5 E2E, performance, security tests, and fixture strategies — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **69A — Test matrix & tooling selection**: Outline E2E/performance/security test scopes, select tooling, and define fixture management strategy.
+    - **69B — Governance & execution plan**: Document execution cadence, CI integration, and reporting templates ensuring traceability to requirements.
 70. [ ] Define 21.6–21.7 Coverage gates and UAT scripts — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **70A — Gate criteria & automation**: Specify coverage thresholds, quality gates, and automation hooks in CI with enforcement steps.
+    - **70B — UAT script authoring & review**: Draft UAT scripts per persona, secure stakeholder sign-off, and schedule execution with evidence capture.
 71. [ ] Execute 22.1–22.4 Migration & Backfill plan (pre-flight, execution, rollback, validation) — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **71A — Pre-flight readiness & runbooks**: Assemble migration inventories, dry-run scripts, rollback plans, and communication templates.
+    - **71B — Execution monitoring & validation**: Perform migrations, monitor telemetry, validate data integrity, and document outcomes with lessons learned.
 72. [ ] Operationalize 23.1–23.3 Analytics KPIs for marketplace health, growth, and monetization — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **72A — KPI definition & data sourcing**: Align on KPI formulas, data sources, and governance; configure ingestion pipelines.
+    - **72B — Dashboard rollout & adoption**: Build visualization dashboards, set review cadences, and train stakeholders with adoption metrics.
 73. [ ] Operationalize 23.4–23.7 Retention metrics, instrumentation, experimentation, and acceptance — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **73A — Instrumentation & experiment design**: Implement retention event tracking, cohort definitions, and experimentation guardrails.
+    - **73B — Reporting & acceptance rituals**: Create retention scorecards, acceptance reviews, and continuous improvement loops with documented learnings.
 74. [ ] Complete 24) Detailed Task Breakdown (WBS) conventions and domain work packages — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **74A — WBS standards & templates**: Define breakdown conventions, templates, and estimation guidelines per domain.
+    - **74B — Domain package creation & review**: Produce domain-specific work packages, review with leads, and integrate into planning tools.
 75. [ ] Produce 25) Example controllers and routes for Laravel implementation patterns — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **75A — Pattern selection & scaffolding**: Identify representative controllers/routes, scaffold examples with annotations and best practices.
+    - **75B — Documentation & validation**: Write explanatory docs, add tests demonstrating usage, and validate against coding standards.
 76. [x] Produce 26) Flutter Retrofit feed client example with interceptors and models — Functionality grade [100/100] | Integration grade [100/100] | UI:UX grade [100/100] | Security grade [100/100]
+    - **76A — API client architecture notes**: Summarize Retrofit setup, interceptor responsibilities, and model mapping strategies used in the example.
+    - **76B — Usage guide & testing evidence**: Provide sample usage snippets, widget integration notes, and reference test coverage ensuring the example remains evergreen.
 77. [x] Deliver 27) Notifications & Chat data models, APIs, features, and safety protocols — Functionality grade [100/100] | Integration grade [100/100] | UI:UX grade [100/100] | Security grade [100/100]
+    - **77A — Data model & API documentation refresh**: Keep entity diagrams and API references aligned with delivered scope.
+    - **77B — Safety protocol retrospectives**: Maintain safety checklists, incident learnings, and regression suites confirming protections stay active.
 78. [ ] Deliver 28) Banners & slow UI fixes across async loading, asset optimization, caching, and measurement — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **78A — Diagnosis & remediation plan**: Audit banners/async pain points, define optimization strategies, and prioritize fixes with metrics.
+    - **78B — Implementation & measurement**: Execute optimizations, update caching strategies, and verify improvements via performance dashboards.
 79. [ ] Deliver 29) Provider-set taxes compliance workflows, validation, invoicing, and privacy handling — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **79A — Workflow design & compliance mapping**: Outline provider tax workflows, compliance checkpoints, and data handling requirements.
+    - **79B — Implementation & audit trails**: Build validation logic, invoicing updates, and privacy safeguards with audit evidence collection.
 80. [ ] Deliver 30) Seeders & demo data factories, seed scripts, sample flows, and acceptance — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **80A — Data model coverage & script planning**: Identify entities requiring seeds, define relationships, and plan script architecture.
+    - **80B — Script implementation & demo validation**: Code factories/seeds, document sample flows, and validate acceptance scenarios in staging environments.
 81. [ ] Deliver 31) Runbooks for deployments, incidents, payments, disputes, and post-incident reviews — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **81A — Runbook authoring framework**: Establish templates, ownership, and escalation paths for each runbook category.
+    - **81B — Review drills & continuous improvement**: Conduct tabletop exercises, capture feedback, and iterate runbooks with version control tracking.
 82. [ ] Deliver 32) Acceptance checklists across domains, mobile, performance, security, and final deliverable — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **82A — Checklist drafting & mapping**: Draft checklists for each domain, link to requirements, and define sign-off owners.
+    - **82B — Operational rollout & auditing**: Integrate checklists into release rituals, gather compliance evidence, and audit adherence periodically.
 83. [ ] Compile Appendix A entity diagram coverage for identity, marketplace, payments, providers, affiliates, taxes, and safety — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **83A — Diagram inventory & updates**: Collect existing diagrams, update with latest entities/relationships, and ensure source files are versioned.
+    - **83B — Review & distribution**: Validate diagrams with domain leads, publish annotated versions, and record acceptance notes.
 84. [ ] Compile Appendix B environment & secrets checklist (namespaces, ownership, matrices, validation) — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **84A — Checklist refresh & ownership alignment**: Update environment/secret entries, confirm ownership and rotation policies, and document gaps.
+    - **84B — Validation tooling & evidence**: Enhance validation scripts (env doctor, CI checks) and capture evidence of successful runs per environment.
 85. [ ] Compile Appendix C i18n & currency implementation guidance and QA — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **85A — Guidance consolidation & gap review**: Audit existing i18n/currency guidance, fill coverage gaps, and align on glossary/terminology.
+    - **85B — QA proof & automation**: Document QA processes, automate key checks (RTL, currency formatting), and archive evidence supporting readiness.
+
+86. [ ] Stand up enterprise architecture governance & roadmap operations — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **86A — Architecture review board enablement**: Define charter, RACI, review cadences, and decision records for cross-domain enterprise architecture oversight.
+    - **86B — Capability roadmap & dependency management**: Produce multi-quarter capability maps, dependency heatmaps, and alignment artifacts feeding portfolio planning.
+87. [ ] Execute enterprise security hardening & zero-trust rollout — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **87A — Zero-trust reference architecture & control mapping**: Document identity, network, device, and data pillars mapped to NIST/CIS controls with gap remediation plans.
+    - **87B — Implementation & continuous assurance**: Deploy MFA, conditional access, micro-segmentation, and automated evidence collection feeding security scorecards.
+88. [ ] Deliver enterprise data governance, residency, and privacy program — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **88A — Data classification & residency framework**: Inventory data assets, classify sensitivity, define residency/sovereignty policies, and publish stewardship model.
+    - **88B — Privacy operations & DPIA automation**: Operationalize DPIA templates, consent lifecycle tooling, and compliance reporting with regulator-ready evidence.
+89. [ ] Integrate enterprise systems (ERP/CRM/ITSM) & workflow automations — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **89A — Integration blueprint & connector development**: Document systems of record, integration patterns, and build reusable connectors/mappings with error handling.
+    - **89B — Automation rollout & monitoring**: Deploy workflow automations (quote-to-cash, case management), establish SLIs, and monitor with alerting/rollback playbooks.
+90. [ ] Establish enterprise service management SLAs, SLOs, and escalation playbooks — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **90A — SLA/SLO design & contract alignment**: Define tiered response/resolution targets, map to contractual obligations, and codify monitoring sources.
+    - **90B — Escalation & customer assurance runbooks**: Build escalation matrices, communication templates, and executive visibility dashboards with live health signals.
+91. [ ] Mature enterprise change management & release governance — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **91A — ITIL-aligned change framework**: Draft change types, CAB workflows, approval automation, and risk scoring rubrics integrated with deployment pipelines.
+    - **91B — Change analytics & compliance reporting**: Instrument change metrics (success rate, MTTR), generate compliance reports, and audit adherence quarterly.
+92. [ ] Achieve enterprise compliance certifications & attestations — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **92A — Control gap assessment & remediation plans**: Map controls to SOC2, ISO 27001, PCI scopes; identify gaps; define remediation sprints with owners/budget.
+    - **92B — Audit readiness & evidence management**: Implement evidence repository, automate collection via tooling, and run mock audits with third-party reviewers.
+93. [ ] Architect enterprise-scale reliability & multi-region resilience — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **93A — Resilience architecture & chaos strategy**: Design multi-region topology, RTO/RPO matrices, and chaos engineering program with scenarios/playbooks.
+    - **93B — Implementation & observability enforcement**: Deploy cross-region failover, disaster recovery drills, and enforce observability SLAs with real-time dashboards.
+94. [ ] Launch enterprise support & customer success operations — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **94A — Support organization design & tooling**: Define tiered support structure, select tooling (ITSM/CRM), and script knowledge base workflows for agents.
+    - **94B — Success playbooks & lifecycle analytics**: Create onboarding/adoption playbooks, QBR cadences, and health scoring dashboards linked to churn predictors.
+95. [ ] Build enterprise analytics, executive reporting, and governance councils — Functionality grade [ ]/100 | Integration grade [ ]/100 | UI:UX grade [ ]/100 | Security grade [ ]/100
+    - **95A — Executive dashboard architecture & KPI harmonization**: Align KPIs across departments, design executive dashboards, and harmonize data definitions/glossary.
+    - **95B — Governance council rituals & decision intelligence**: Establish executive councils, meeting cadences, and decision logs leveraging analytics insights for strategic planning.
 


### PR DESCRIPTION
## Summary
- extend the FixIt checklist with enterprise-scale governance, security, and resilience tracks
- capture detailed A/B subtasks for architecture, compliance, support, and analytics programs

## Testing
- not run; documentation-only change

------
https://chatgpt.com/codex/tasks/task_e_68dc345c9a3083208bc71a3d6ffb43c5